### PR TITLE
Update to PSR-4

### DIFF
--- a/HostingerApi.php
+++ b/HostingerApi.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Hostinger\HostingerApi;
+
 class HostingerApi
 {
     protected $username = '';

--- a/HostingerApiException.php
+++ b/HostingerApiException.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Hostinger\HostingerApi;
+
 class HostingerApiException extends \Exception {
 
 }

--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,8 @@
     "ext-json": "*"
   },
   "autoload": {
-    "psr-0": {
-      "HostingerApi": "",
-      "HostingerApiException": ""
+    "psr-4": {
+      "Hostinger\\HostingerApi\\": ""
     }
   }
 }


### PR DESCRIPTION
Update to use PSR-4 with a namespace. PSR-0 has been deprecated since 2014 and is no longer recommended.

It would probably be worth moving the files to a `src` directory as well, but I didn't include that.